### PR TITLE
feat: combat, statusIfHit and backUp Done

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -200,6 +200,23 @@ case 'END_TURN':
     broadcastToRoom(player.currentRoom);
     break;
 
+
+    case 'RECEIVE_ATTACK':
+    room.gameState = {
+        ...room.gameState,
+        units: room.gameState.units.map(existingUnit => {
+            if (existingUnit.id === message.updatedUnit.id) { 
+                return {
+                    ...message.updatedUnit
+                };
+            }
+            return existingUnit;
+        })
+    };
+    
+    broadcastToRoom(player.currentRoom);
+    break;
+
     case 'USE_SKILL':
       const caster = room.gameState.units.find(u => u.id === message.casterId);
       if (!caster) return;

--- a/src/game/servants/archer/Anastasia_unit.js
+++ b/src/game/servants/archer/Anastasia_unit.js
@@ -27,6 +27,7 @@ const mahalaprayaMicroAction = new MicroAction({
                 const backUpUnit = modifiedUnit;
                     // Create modified attributes for the copy
 
+                const currentEffects = Array.isArray(modifiedUnit.effects) ? modifiedUnit.effects : [];
                 
                 // const newHp = Math.max(0, modifiedUnit.hp - (5 * caster.atk));
 
@@ -46,7 +47,7 @@ const mahalaprayaMicroAction = new MicroAction({
                 console.log(caster.combatSent);
                 modifiedUnit.combatReceived = JSON.parse(JSON.stringify(combat.combatResults));
 
-                const currentEffects = Array.isArray(modifiedUnit.effects) ? modifiedUnit.effects : [];
+
                 const newEffect = {
                     name: 'uwu',
                     duration: 7,


### PR DESCRIPTION
Combat was mostly implemented, we are pending some things:

1) Receive attack is shown all the time (we eliminated the If at the beginning), we should move it to the context menu > other actions > common actions 2) We must implement responses to combat (evade, block, etc...); What I think we 2 possible approaches, a) we could add the action "evade" to the "reactions" and a parameter "canBeUsedAsReaction" to action, if true it will add to the list of "reactions", or b) we could "evade" to  other actions > common actions